### PR TITLE
added basic phpunit support via travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ php:
 env:
   - WP_VERSION=master WP_MULTISITE=0
   - WP_VERSION=master WP_MULTISITE=1
-  - WP_VERSION=3.5.2 WP_MULTISITE=0
-  - WP_VERSION=3.5.2 WP_MULTISITE=1
+  - WP_VERSION=3.6 WP_MULTISITE=0
+  - WP_VERSION=3.6 WP_MULTISITE=1
 
 # Grab the setup script and execute
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+# Main Travis CI configuration file for wordpress-plugin tests
+# https://github.com/benbalter/wordpress-plugin-tests
+
+# Tell Travis CI we're using PHP
+language: php
+
+# Versions of PHP to test against
+php:
+#  - 5.2
+  - 5.3
+  - 5.4
+  - 5.5
+#  - 6.0
+  
+# Specify versions of WordPress to test against
+# WP_VERSION = WordPress version number (use "master" for SVN trunk)
+# WP_MULTISITE = whether to test multisite (use either "0" or "1")
+env:
+  - WP_VERSION=master WP_MULTISITE=0
+  - WP_VERSION=master WP_MULTISITE=1
+  - WP_VERSION=3.5.2 WP_MULTISITE=0
+  - WP_VERSION=3.5.2 WP_MULTISITE=1
+
+# Grab the setup script and execute
+before_script:
+    - wget https://raw.github.com/wp-repository/wp-repository.codex/phpunit-generic/setup.sh
+    - source setup.sh
+
+script: phpunit
+
+# Tells Travis CI to run unit tests against certain branches
+branches:
+  except:
+    - assets
+    - upstream
+
+# Reduce mail notifications by Travis CI to a minimum
+notifications:
+  email:
+    on_success: change
+    on_failure: always

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # WP No Taxonomy Base
 __Remove base slug from your custom taxonomy terms.__
 
-[Homepage][1.1] | [WordPress.org][1.2]
+Master: [![Build Status](https://travis-ci.org/markoheijnen/wp-no-taxonomy-base.png?branch=master)](https://travis-ci.org/markoheijnen/wp-no-taxonomy-base)
 
-| WordPress					| Version			| *		| Development				|					|
-| ----:						| :----				| :---: | :----						| :----				|
-| Requires at least:		| __3.1__			| *		| [GitHub-Repository][1.3]	| [Translate][1.6]	|
-| Tested up to:				| __3.6__			| *		| [Issue-Tracker][1.4]		|					|
-| Current stable release:	| __[1.1][1.5]__	| *		| Current dev version:		| [1.2-dev][1.7]	|
+| *						| WordPress					| Version			| *		| Development				|					|
+| :----					| ----:						| :----				| :---: | :----						| :----				|
+| [Homepage][1.1]		| Requires at least:		| __3.1__			| *		| [GitHub-Repository][1.3]	| [Translate][1.6]	|
+| *						| Tested up to:				| __3.6__			| *		| [Issue-Tracker][1.4]		|					|
+| *						| Current stable release:	| __[1.1][1.5]__	| *		| Current dev version:		| [1.2-dev][1.7]	|
 
 [1.1]: http://markoheijnen.com
 [1.2]: #

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Bootstrap the testing environment
+ * Uses wordpress tests (http://github.com/nb/wordpress-tests/) which uses PHPUnit
+ * @package wordpress-plugin-tests
+ *
+ * Usage: change the below array to any plugin(s) you want activated during the tests
+ *        value should be the path to the plugin relative to /wp-content/
+ *
+ * Note: Do note change the name of this file. PHPUnit will automatically fire this file when run.
+ *
+ */
+
+$GLOBALS['wp_tests_options'] = array(
+	'active_plugins' => array( 'wp-no-taxonomy-base/wp-no-taxonomy-base.php' ),
+);
+
+require dirname( __FILE__ ) . '/lib/bootstrap.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,11 @@
+<phpunit
+    bootstrap="./bootstrap.php"
+    backupGlobals="false"
+    colors="true"
+>
+    <testsuites>
+        <testsuite>
+            <directory prefix="test_" suffix=".php">./</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/test_wordpress_plugin_tests.php
+++ b/tests/test_wordpress_plugin_tests.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Tests to test that that testing framework is testing tests. Meta, huh?
+ * @package wordpress-plugins-tests
+ */
+class WP_Test_WordPress_Plugin_Tests extends WP_UnitTestCase {
+	
+	/**
+	 * Run a simple test to ensure that the tests are running
+	 */
+	 function test_tests() {
+		 
+		 $this->assertTrue( true );
+		 
+	 }
+	
+	/**
+	 * Verify that WordPress is installed and is the version that we requested
+	 */
+	function test_wp_version() {
+		
+		if ( !getenv( 'TRAVIS_PHP_VERSION' ) )
+			$this->markTestSkipped( 'Not running on Travis CI' );
+		
+		//grab the requested version
+		$requested_version = getenv( 'WP_VERSION' );
+		
+		//trunk is always "master" in github terms, but WordPress has a specific way of describing it
+		//grab the exact version number to verify that we're on trunk
+		if ( $requested_version == 'master' ) {
+			$file = file_get_contents( 'https://raw.github.com/WordPress/WordPress/master/wp-includes/version.php' );
+			preg_match( '#\$wp_version = \'([^\']+)\';#', $file, $matches );
+			$requested_version = $matches[1];
+		}
+		
+		$this->assertEquals( get_bloginfo( 'version' ), $requested_version );
+	
+	}
+	
+}


### PR DESCRIPTION
phpunit testing via travis-ci.org
- just merge the request
- go to www.travis-ci.org and login with your github creds
- open https://travis-ci.org/profile (if you not get redirected there - you might be)
- activate the plugin
- DONE :smiling_imp:

This way we can catch errors with php versions we do not run ourselves 
