### PR TITLE
Rewrites permalinks without category slug

### DIFF
--- a/wp-no-taxonomy-base.php
+++ b/wp-no-taxonomy-base.php
@@ -53,6 +53,8 @@ if ( ! class_exists('WP_No_Taxonomy_Base') ) {
 			add_action( 'edited_category', array( $this, 'flush_rules' ) );
 
 			add_filter( 'category_rewrite_rules', array( $this, 'add_rules' ) );
+			
+            add_action('init', array($this , 'no_category_base_permastruct'    )  ) ;			
 		}
 
 		public function flush_rules() {
@@ -60,6 +62,22 @@ if ( ! class_exists('WP_No_Taxonomy_Base') ) {
 
 			$wp_rewrite->flush_rules();
 		}
+		
+		
+        /**
+         * Removes category base.
+         *
+         * @return void
+         */
+        public function no_category_base_permastruct() {
+        	global $wp_rewrite;
+          global $wp_version;
+          if ($wp_version >= 3.4) {
+        	  $wp_rewrite->extra_permastructs['category']['struct'] = '%category%';
+          } else {
+            $wp_rewrite->extra_permastructs['category'][0] = '%category%';
+          }
+        }		
 
 
 		public function redirect() {

--- a/wp-no-taxonomy-base.php
+++ b/wp-no-taxonomy-base.php
@@ -42,6 +42,8 @@ if ( ! class_exists('WP_No_Taxonomy_Base') ) {
 	class WP_No_Taxonomy_Base {
 
 		public function __construct() {
+            add_action('category_rewrite_rules', array($this , 'no_category_base_permastruct'    )  ) ;			
+	    		    
 			add_filter( 'template_redirect', array( $this, 'redirect' ) );
 			add_filter( 'term_link', array( $this, 'correct_term_link' ), 10, 3 );
 
@@ -54,7 +56,6 @@ if ( ! class_exists('WP_No_Taxonomy_Base') ) {
 
 			add_filter( 'category_rewrite_rules', array( $this, 'add_rules' ) );
 			
-            add_action('init', array($this , 'no_category_base_permastruct'    )  ) ;			
 		}
 
 		public function flush_rules() {


### PR DESCRIPTION
This rewrites URLs to remove the category slug. It looks like this is hardcoded specifically for the default category taxonomy, so should probably be fully abstracted, but solved my limitation with this plugin, so figured I'd share. 

I'd ticketed this as #22

Source: http://github.com/mines/no-category-base-wpml
